### PR TITLE
Fix compile error in non-x64/non-ARM architectures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Hashing/issues/11
-Your prepared branch: issue-11-15b3b102
-Your prepared working directory: /tmp/gh-issue-solver-1757591528384
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Hashing/issues/11
+Your prepared branch: issue-11-15b3b102
+Your prepared working directory: /tmp/gh-issue-solver-1757591528384
+
+Proceed.

--- a/cpp/Platform.Hashing/Platform.Hashing.Crc32.h
+++ b/cpp/Platform.Hashing/Platform.Hashing.Crc32.h
@@ -86,6 +86,8 @@ size_t crc32default(const uint8_t* data, size_t bytes, size_t prev) {
   else {
     ptr = crc32fallback;
   }
+#else
+  ptr = crc32fallback;
 #endif
   cpuinfo_deinitialize();
   atomicFuncPtr.store(ptr, std::memory_order_relaxed);


### PR DESCRIPTION
## Summary

This PR fixes a compilation error that occurs when building the library on architectures other than x86_64 and AArch64.

## Problem

The issue was in the `crc32default` function in `Platform.Hashing.Crc32.h`. The function had conditional compilation blocks for x86_64 and AArch64 architectures, but no fallback case for other architectures. This left the `ptr` variable uninitialized on unsupported platforms, causing compilation errors.

## Solution

Added an `#else` branch to the architecture-specific conditional compilation block that sets `ptr = crc32fallback` for any architecture that is neither x86_64 nor AArch64. This ensures the library compiles and works correctly on all platforms by falling back to the software-only CRC32 implementation.

## Changes

- Added `#else ptr = crc32fallback;` fallback case in `crc32default` function for unsupported architectures
- Maintains full functionality on x86_64 and AArch64 while providing compatibility for other platforms

## Test Plan

- [x] Code compiles without errors on the target platform
- [x] Fallback implementation is properly assigned for unsupported architectures
- [x] No functional changes to existing x86_64 and AArch64 code paths

Fixes #11

🤖 Generated with [Claude Code](https://claude.ai/code)